### PR TITLE
Add Ollama configuration example

### DIFF
--- a/.env.open_source.example
+++ b/.env.open_source.example
@@ -1,0 +1,68 @@
+# neo4j authentication
+NEO4J_USERNAME=neo4j
+NEO4J_PASSWORD=change-me!
+
+# neo4j graph database URI used by the backend to connect to neo4j
+# use "bolt://localhost" when the backend and neo4j are both running locally outside Docker
+# use "bolt://host.docker.internal" when the backend is running within Docker but neo4j is running locally (outside Docker)
+# URI will be set to the neo4j container's host if using Docker Compose
+NEO4J_URI=bolt://localhost:7687
+
+# port configuration is optional
+# used with Docker Compose to expose neo4j on non-default ports
+NEO4J_HTTP_PORT=7474
+NEO4J_BOLT_PORT=7687
+
+# files location
+FILES_DIRECTORY=files
+
+# redis cache configuration
+REDIS_HOST="localhost"
+
+# backend LLM properties
+MISTRAL_KEY=my-api-key
+
+# OpenAI LLM properties
+OPENAI_KEY=my-openai-api-key
+# Ollama base URL
+OLLAMA_URL=http://localhost:11434
+# Use these variables to mix open-source and commercial models.
+# Set each *_LLM and *_MODEL value to either "ollama", "openai" or "mistral" as needed.
+
+# frontend host - used to configure backend CORS
+FRONTEND_URL=http://localhost:8650
+
+# what backend URL should be used by frontend API requests
+BACKEND_URL=http://localhost:8250
+
+# websockets url to conect to backend websocket endpoint
+WS_URL=ws://localhost:8250/ws
+
+# llm
+ANSWER_AGENT_LLM="ollama"
+INTENT_AGENT_LLM="ollama"
+REPORT_AGENT_LLM="ollama"
+MATERIALITY_AGENT_LLM="ollama"
+VALIDATOR_AGENT_LLM="ollama"
+DATASTORE_AGENT_LLM="ollama"
+WEB_AGENT_LLM="ollama"
+CHART_GENERATOR_LLM="ollama"
+ROUTER_LLM="ollama"
+FILE_AGENT_LLM="ollama"
+SUGGESTIONS_LLM="ollama"
+DYNAMIC_KNOWLEDGE_GRAPH_LLM="ollama"
+
+
+# model
+ANSWER_AGENT_MODEL="llama3:8b"
+INTENT_AGENT_MODEL="deepseek-coder:6b-instruct"
+REPORT_AGENT_MODEL="llama3:8b"
+MATERIALITY_AGENT_MODEL="deepseek-coder:6b-instruct"
+VALIDATOR_AGENT_MODEL="llama3:8b"
+DATASTORE_AGENT_MODEL="deepseek-coder:6b-instruct"
+WEB_AGENT_MODEL="llama3:8b"
+CHART_GENERATOR_MODEL="deepseek-coder:6b-instruct"
+ROUTER_MODEL="llama3:8b"
+FILE_AGENT_MODEL="deepseek-coder:6b-instruct"
+SUGGESTIONS_MODEL="llama3:8b"
+DYNAMIC_KNOWLEDGE_GRAPH_MODEL="llama3:8b"

--- a/README.md
+++ b/README.md
@@ -97,6 +97,22 @@ Configuration steps:
 - Copy the `.env.example` file at the root of this project.
 - Rename the copied file as `.env`.
 - Update the `.env` file with your wanted configuration following the guidance in the file.
+- For a configuration that uses open-source models with Ollama, copy `\.env.open_source.example` instead.
+  Ensure you install a recent version of `ollama` (0.1.33 or newer) so the Python
+  dependencies resolve cleanly.
+
+### Using Ollama with DeepSeek and Llama 3
+
+InferESG can run on locally hosted models through [Ollama](https://ollama.com/).
+Install Ollama and pull models suitable for an 8GB GPU:
+
+```bash
+ollama pull llama3:8b
+ollama pull deepseek-coder:6b-instruct
+```
+
+Set `OLLAMA_URL` in your `.env` (defaults to `http://localhost:11434`) and configure the desired `*_LLM` variables to `ollama`.
+The `.env.open_source.example` file demonstrates a full open-source configuration. Mix commercial and open-source models by setting each `*_LLM` and `*_MODEL` variable individually.
 
 ### Running the application
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -19,6 +19,10 @@ matplotlib==3.9.1
 pytest-bdd==7.3.0
 langchain==0.3.4
 langchain-openai==0.2.3
+# Use a newer Ollama release to avoid httpx conflicts
+ollama>=0.1.33
+# Constrain httpx so all LLM clients share a compatible version
+httpx>=0.27.0,<0.28.0
 python-multipart==0.0.17
 pillow==10.4.0
 pypdf==4.3.1

--- a/backend/src/llm/__init__.py
+++ b/backend/src/llm/__init__.py
@@ -3,5 +3,14 @@ from .factory import get_llm
 from .mistral import Mistral
 from .count_calls import count_calls
 from .openai import OpenAI
+from .ollama import Ollama
 
-__all__ = ["count_calls", "get_llm", "LLM", "LLMFile", "Mistral", "OpenAI"]
+__all__ = [
+    "count_calls",
+    "get_llm",
+    "LLM",
+    "LLMFile",
+    "Mistral",
+    "OpenAI",
+    "Ollama",
+]

--- a/backend/src/llm/ollama.py
+++ b/backend/src/llm/ollama.py
@@ -1,0 +1,49 @@
+import logging
+from fastapi import HTTPException
+from ollama import AsyncClient
+from src.utils import Config
+from src.llm.llm import LLM, LLMFile
+from src.session.file_uploads import get_file_content_for_filename, set_file_content_for_filename
+from src.utils.file_utils import extract_text
+
+logger = logging.getLogger(__name__)
+config = Config()
+
+
+class Ollama(LLM):
+    def __init__(self):
+        self.client = AsyncClient(base_url=config.ollama_url or "http://localhost:11434")
+
+    async def chat(self, model: str, system_prompt: str, user_prompt: str, return_json: bool = False) -> str:
+        try:
+            response = await self.client.chat(
+                model=model,
+                messages=[
+                    {"role": "system", "content": system_prompt},
+                    {"role": "user", "content": user_prompt},
+                ],
+            )
+            return response["message"]["content"]
+        except Exception as e:  # pragma: no cover - network errors
+            logger.exception(f"Error calling Ollama model: {e}")
+            return "An error occurred while processing the request."
+
+    async def chat_with_file(
+        self,
+        model: str,
+        system_prompt: str,
+        user_prompt: str,
+        files: list[LLMFile],
+        return_json: bool = False,
+    ) -> str:
+        try:
+            for file in files:
+                extracted_content = get_file_content_for_filename(file.filename)
+                if not extracted_content:
+                    extracted_content = extract_text(file)
+                    set_file_content_for_filename(file.filename, extracted_content)
+                user_prompt += f"\n\nDocument:\n{extracted_content}"
+            return await self.chat(model, system_prompt, user_prompt, return_json)
+        except Exception as file_error:  # pragma: no cover - simple wrapper
+            logger.exception(file_error)
+            raise HTTPException(status_code=500, detail=f"Failed to process files: {file_error}") from file_error

--- a/backend/src/utils/config.py
+++ b/backend/src/utils/config.py
@@ -27,6 +27,7 @@ class Config(object):
         self.router_llm = None
         self.suggestions_llm = None
         self.dynamic_knowledge_graph_llm = None
+        self.ollama_url = None
         self.validator_agent_model = None
         self.intent_agent_model = None
         self.answer_agent_model = None
@@ -53,6 +54,7 @@ class Config(object):
             self.mistral_key = os.getenv("MISTRAL_KEY")
             self.mistral_model = os.getenv("MODEL")
             self.openai_key = os.getenv("OPENAI_KEY")
+            self.ollama_url = os.getenv("OLLAMA_URL", "http://localhost:11434")
             self.neo4j_uri = os.getenv("NEO4J_URI", default_neo4j_uri)
             self.neo4j_user = os.getenv("NEO4J_USERNAME")
             self.neo4j_password = os.getenv("NEO4J_PASSWORD")


### PR DESCRIPTION
## Summary
- provide `.env.open_source.example` showing how to use Ollama models
- restore `.env.example` with commercial model defaults
- document the new config file and how to mix open source and commercial models
- pin httpx to avoid conflicts and require a newer Ollama release

## Testing
- `pytest -q` *(fails: 31 errors during collection)*


------
https://chatgpt.com/codex/tasks/task_b_686d32ec9a78832a85c4630b83ff153a